### PR TITLE
[dns] cache results and check before forward

### DIFF
--- a/authorizer/activity.go
+++ b/authorizer/activity.go
@@ -53,7 +53,7 @@ func (f *Authorizer) ttlCacheChecker() (*ServiceContext, error) {
 				if !f.doNotFlushAuthorizedHosts {
 					for h := range f.cache.Hosts {
 						l.Infof("Removing host [%s] from firewall rules", h)
-						err := f.fw.DeleteIPv4FromSetRule(f.authorizedSet, h)
+						err := f.fw.DeleteIPv4FromAuthorizedList(f.authorizedSet, h)
 						if err != nil {
 							l.Error(err)
 						}
@@ -88,7 +88,7 @@ func (f *Authorizer) ttlCacheChecker() (*ServiceContext, error) {
 					// Blocking call, but we expect this to be fast to mitigate any wait that
 					// RequestHandler may encounter
 					l.Debugf("Host [%s] has expired. Removing from firewall rules", h)
-					err := f.fw.DeleteIPv4FromSetRule(f.authorizedSet, h)
+					err := f.fw.DeleteIPv4FromAuthorizedList(f.authorizedSet, h)
 					if err != nil {
 						l.Error(err)
 					}

--- a/authorizer/errors.go
+++ b/authorizer/errors.go
@@ -1,8 +1,18 @@
 package authorizer
 
 var (
-	errNil     string = "authorizer has not been initialized, starting ttl cache checker is forbidden"
-	errTTL     string = "ttl ticker can not be 0 or negative"
-	errSetName string = "authorized set can not be empty"
-	warnTTL    string = "ttl ticker is set to be %d sec. Please note that cache checks are blocking, frequent calls means frequent blocks"
+	errNil            string = "authorizer has not been initialized, starting ttl cache checker is forbidden"
+	errTTL            string = "ttl ticker can not be 0 or negative"
+	errSetName        string = "authorized set can not be empty"
+	errInvalidReply   string = "[Invalid] query has Qtype %s but we could not read answer for question: %s"
+	warnTTL           string = "ttl ticker is set to be %d sec. Please note that cache checks are blocking, frequent calls means frequent blocks"
+	warnPTRIPv6       string = "[PTR IPv6] Question %s resolved to %s but was not authorized. NetTrust does not support IPv6 yet"
+	warnIPv6Support   string = "[IPv6] Question: %s Host: %s NetTrust does not support IPv6 yet"
+	infoNotHandled    string = "[Not Handled] Question %s - Is this local?"
+	infoBlockedNX     string = "[Blocked] Question %s"
+	infoPTRIPv4       string = "[PTR IPv4] Question %s with host %s resolved to %s"
+	infoAuthBlacklist string = "[Blacklisted] Question %s Host: %s"
+	infoAuthBlock     string = "[Blocked] Question %s"
+	infoAuthExists    string = "[Already Authorized] Question %s Host: %s"
+	infoAuth          string = "[Authorized] Question %s Hosts: [%s]"
 )

--- a/authorizer/handler.go
+++ b/authorizer/handler.go
@@ -14,69 +14,122 @@ func (f *Authorizer) HandleRequest(resp *dns.Msg) error {
 		return fmt.Errorf(errNil)
 	}
 
-	dnsQuestions := []string{}
-	for _, q := range resp.Question {
-		dnsQuestions = append(
-			dnsQuestions,
-			fmt.Sprintf("Question: %s", q.Name),
-		)
-	}
+	question := resp.Question[0].Name
 
 	if resp.Rcode != dns.RcodeSuccess {
-		f.fwl.Infof("[Not Handled] %s - Is this local?", strings.Join(dnsQuestions, " "))
+		f.fwl.Infof(infoNotHandled, question)
 		return nil
 	}
 
 	if len(resp.Answer) == 0 {
-		f.fwl.Infof("[Blocked] %s", strings.Join(dnsQuestions, " "))
+		f.fwl.Infof(infoBlockedNX, question)
 		return nil
 	}
 
-	for _, answer := range resp.Answer {
-		if r, ok := answer.(*dns.A); ok {
-			blacklisted, err := f.checkBlacklist(r.A.String())
+	if resp.Question[0].Qtype == dns.TypeA {
+		for _, answer := range resp.Answer {
+			if _, ok := answer.(*dns.CNAME); ok {
+				// Nothing to do here for now. CNAME is not IP Address
+				// this should not be a problem since usually CNAME
+				// addresses are answered in the same query
+				continue
+			}
+
+			r, ok := answer.(*dns.A)
+			if !ok {
+				f.fwl.Errorf(errInvalidReply, "TypeA", question)
+				continue
+			}
+
+			err := f.authIPv4(question, r.A.String())
 			if err != nil {
 				f.fwl.Error(err)
-				continue
 			}
+		}
 
-			if blacklisted {
-				f.fwl.Infof("[Blocked] %s Host: %s", strings.Join(dnsQuestions, " "), r.A.String())
-				continue
-			}
+		return nil
+	}
 
-			if r.A.String() == "0.0.0.0" {
-				f.fwl.Infof("[Blocked] %s", strings.Join(dnsQuestions, " "))
-				continue
+	if resp.Question[0].Qtype == dns.TypeAAAA {
+		for _, answer := range resp.Answer {
+			if r, ok := answer.(*dns.AAAA); ok {
+				// Not supported yet
+				f.fwl.Warnf(warnIPv6Support, question, r.AAAA.String())
 			}
-
-			regOK := f.cache.Register(r.A.String())
-			if !regOK {
-				f.cache.Renew(r.A.String())
-				f.fwl.Infof("[Already Authorized] %s Host: %s", strings.Join(dnsQuestions, " "), r.A.String())
-				continue
-			}
-
-			err = f.fw.AddIPv4ToSetRule(f.authorizedSet, r.A.String())
-			if err != nil {
-				f.fwl.Error(err)
-				continue
-			}
-			f.fwl.Infof("[Authorized] %s Hosts: [%s]", strings.Join(dnsQuestions, " "), r.A.String())
-		} else if _, ok := answer.(*dns.CNAME); ok {
-			// Nothing to do here for now. CNAME is not IP Address
-			// this should not be a problem since usually CNAME
-			// addresses are answered in the same query
-			continue
-		} else if r, ok := answer.(*dns.AAAA); ok {
-			// Not supported yet
-			if r.AAAA.String() == "0.0.0.0" {
-				continue
-			}
-		} else if r, ok := answer.(*dns.PTR); ok {
-			f.fwl.Infof("[PTR] %s resolved to %s", strings.Join(dnsQuestions, " "), r.Ptr)
 		}
 	}
+
+	if resp.Question[0].Qtype == dns.TypePTR {
+		answerSlice := []string{}
+		for _, answer := range resp.Answer {
+			r, ok := answer.(*dns.PTR)
+			if !ok {
+				f.fwl.Errorf(errInvalidReply, "TypePTR", question)
+				continue
+			}
+			answerSlice = append(answerSlice, r.Ptr)
+		}
+
+		if t := strings.Split(question, ".arpa")[0]; strings.HasSuffix(t, ".ip6") {
+			f.fwl.Warnf(warnPTRIPv6, question, strings.Join(answerSlice, " "))
+			return nil
+		}
+
+		// Split PTR Question BE IPv4 string
+		revAddr := strings.Split(question, ".in-addr.arpa")[0]
+
+		// Split BE IPv4 string into a slice
+		revAddrSlice := strings.Split(revAddr, ".")
+		addrSlice := []string{}
+
+		// Convert to LE
+		for i := len(revAddrSlice) - 1; i >= 0; i-- {
+			addrSlice = append(addrSlice, revAddrSlice[i])
+		}
+
+		// Construct back IPv4 into LE
+		addr := strings.Join(addrSlice, ".")
+		f.fwl.Infof(infoPTRIPv4, question, addr, strings.Join(answerSlice, ""))
+
+		err := f.authIPv4(question, addr)
+		if err != nil {
+			f.fwl.Error(err)
+		}
+
+		return nil
+	}
+
+	return nil
+}
+
+func (f *Authorizer) authIPv4(question, ip string) error {
+	blacklisted, err := f.checkBlacklist(ip)
+	if err != nil {
+		return err
+	}
+
+	if blacklisted {
+		f.fwl.Infof(infoAuthBlacklist, question, ip)
+		return nil
+	}
+
+	if ip == "0.0.0.0" {
+		f.fwl.Infof(infoAuthBlock, question)
+		return nil
+	}
+
+	regOK := f.cache.Register(ip)
+	if !regOK {
+		f.cache.Renew(ip)
+		f.fwl.Infof(infoAuthExists, question, ip)
+		return nil
+	}
+
+	err = f.fw.AddIPv4ToSetRule(f.authorizedSet, ip)
+	if err != nil {
+		return err
+	}
+	f.fwl.Infof(infoAuth, question, ip)
 
 	return nil
 }

--- a/cmd/nettrust.go
+++ b/cmd/nettrust.go
@@ -61,6 +61,7 @@ func main() {
 		config.FWDCaCert,
 		config.ListenTLS,
 		config.FWDTLS,
+		config.DNSTTLCache,
 		logger,
 	)
 	if err != nil {

--- a/config.json
+++ b/config.json
@@ -18,6 +18,8 @@
     "listenCertKey": "",
     "firewallType": "nftables",
 
+    "dnsTTLCache": 30,
+
     "whitelistLoEnabled": true,
     "whitelistPrivateEnabled": true,
     "ttl": -1,

--- a/core/checks.go
+++ b/core/checks.go
@@ -18,7 +18,7 @@ func emptyStringE(s string) error {
 func CheckIPV4SocketAddress(address string) error {
 	strSlice := strings.Split(address, ":")
 	if len(strSlice) != 2 {
-		return fmt.Errorf("address [%s] is not valid. Expected ip:port", address)
+		return fmt.Errorf(errInvalidSocketAddress, address)
 	}
 
 	if es := emptyStringE(strSlice[0]); es != nil {
@@ -34,7 +34,7 @@ func CheckIPV4SocketAddress(address string) error {
 	}
 
 	if port < 1 || port > 65535 {
-		return fmt.Errorf("invalid port [%d] number", port)
+		return fmt.Errorf(errInvalidPort, port)
 	}
 
 	if err := CheckIPV4Addresses(strSlice[0]); err != nil {
@@ -55,7 +55,7 @@ func CheckIPV4Addresses(addr string) error {
 			return err
 		}
 		if octInt < 0 || octInt > 255 {
-			return fmt.Errorf("not a valid ipv4 address [%s]", addr)
+			return fmt.Errorf(errNotValidIPv4Addr, addr)
 		}
 	}
 
@@ -77,7 +77,7 @@ func CheckIPV4Network(addr string) error {
 	}
 
 	if cidr < 0 || cidr > 32 {
-		return fmt.Errorf("not a valid ipv4 network [%s]", addr)
+		return fmt.Errorf(errNotValidIPv4Network, addr)
 	}
 
 	return nil

--- a/core/env.go
+++ b/core/env.go
@@ -37,6 +37,7 @@ type NetTrust struct {
 	WhitelistPrivate          []string
 	AuthorizedTTL             int `json:"ttl"`
 	TTLCheckTicker            int `json:"ttlInterval"`
+	DNSTTLCache               int `json:"dnsTTLCache"`
 }
 
 // GetNetTrustEnv will read environ and create a map of k:v from envs
@@ -90,6 +91,8 @@ func GetNetTrustEnv() (*NetTrust, error) {
 		"How often NetTrust should check the cache for expired authorized hosts (Checking is blocking, do not put small numbers)",
 	)
 	fileCFG := flag.String("config", "", "Path to config.json")
+	dnsTTLCache := flag.Int("dns-ttl-cache", 0, "Number of seconds dns queries stay in cache")
+
 	flag.Parse()
 
 	var key string
@@ -213,6 +216,12 @@ func GetNetTrustEnv() (*NetTrust, error) {
 		config.TTLCheckTicker = 30
 	} else if *ttlCheckTicker != 0 {
 		config.TTLCheckTicker = *ttlCheckTicker
+	}
+
+	if *dnsTTLCache == 0 && config.DNSTTLCache == 0 {
+		config.DNSTTLCache = 30
+	} else if *dnsTTLCache != 0 {
+		config.DNSTTLCache = *dnsTTLCache
 	}
 
 	if *whitelistLoopback || config.WhitelistLoEnabled {

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,8 +1,12 @@
 package core
 
 var (
-	errSameAddr        string = "listen address can not be the same as forward address"
-	errListenTLSNoFile string = "listen-tls is enabled but no %s was provided"
+	errSameAddr             string = "listen address can not be the same as forward address"
+	errListenTLSNoFile      string = "listen-tls is enabled but no %s was provided"
+	errInvalidSocketAddress string = "address [%s] is not valid. Expected ip:port"
+	errInvalidPort          string = "invalid port [%d] number"
+	errNotValidIPv4Addr     string = "not a valid ipv4 address [%s]"
+	errNotValidIPv4Network  string = "not a valid ipv4 network [%s]"
 
 	// WarnOnExitFlushAuthorized will be printed when authorized hosts are preserved on NetTrust exit
 	WarnOnExitFlushAuthorized string = "on exit NetTrust will not flush the authorized hosts list"

--- a/dns/cache/cache.go
+++ b/dns/cache/cache.go
@@ -1,0 +1,207 @@
+package queries
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Answered for storing dns replies with TTL
+type Answered struct {
+	M *dns.Msg
+	T time.Time
+}
+
+// Queries for storing dns answers
+type Queries struct {
+	sync.Mutex
+	ttl      int
+	resolved map[string]Answered
+	nx       map[string]time.Time
+}
+
+// NewCache creates a new empty cache
+func NewCache(ttl int) *Queries {
+	return &Queries{
+		ttl:      ttl,
+		resolved: make(map[string]Answered),
+		nx:       make(map[string]time.Time),
+	}
+}
+
+// Question returns dns.Msg.Question[0].Name from a given dns message
+func (c *Queries) Question(msg *dns.Msg) string {
+	return strings.TrimSuffix(msg.Question[0].Name, ".")
+}
+
+// Exists (blocking) returns true if a question is in cache
+func (c *Queries) Exists(msg *dns.Msg) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	_, ok := c.resolved[c.Question(msg)]
+
+	return ok
+}
+
+// ExistsNX (blocking) returns true if a question is in NX cache
+func (c *Queries) ExistsNX(msg *dns.Msg) bool {
+	c.Lock()
+	defer c.Unlock()
+
+	_, ok := c.nx[c.Question(msg)]
+
+	return ok
+}
+
+// HasExpired for checking if a specific question in cache has expired
+func (c *Queries) HasExpired(msg *dns.Msg) bool {
+	if !c.Exists(msg) {
+		return true
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	q := c.resolved[c.Question(msg)]
+
+	return time.Since(q.T) > time.Second*time.Duration(c.ttl)
+}
+
+// HasExpiredNX for checking if a specific question in NX cache has expired
+func (c *Queries) HasExpiredNX(msg *dns.Msg) bool {
+	if !c.ExistsNX(msg) {
+		return true
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	q := c.nx[c.Question(msg)]
+
+	return time.Since(q) > time.Second*time.Duration(c.ttl)
+}
+
+// Get for getting a cached question from the cache
+func (c *Queries) Get(msg *dns.Msg) *dns.Msg {
+	if c.Exists(msg) {
+		return c.resolved[c.Question(msg)].M
+	}
+
+	return nil
+}
+
+// Register (blocking) for adding a new question to cache
+func (c *Queries) Register(msg *dns.Msg) bool {
+	if c.Exists(msg) {
+		return false
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.resolved[c.Question(msg)] = Answered{
+		M: msg,
+		T: time.Now(),
+	}
+
+	return true
+}
+
+// RegisterNX (blocking) for adding a new question to NX cache
+func (c *Queries) RegisterNX(msg *dns.Msg) bool {
+	if c.ExistsNX(msg) {
+		return false
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.nx[c.Question(msg)] = time.Now()
+
+	return true
+}
+
+// Renew (blocking) for updating ttl for a question in cache
+func (c *Queries) Renew(msg *dns.Msg) bool {
+	if !c.Exists(msg) {
+		return c.Register(msg)
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	e := c.resolved[c.Question(msg)]
+
+	e.T = time.Now()
+
+	return true
+}
+
+// RenewNX (blocking) for updating a ttl for a question in NX cache
+func (c *Queries) RenewNX(msg *dns.Msg) bool {
+	if !c.ExistsNX(msg) {
+		return c.RegisterNX(msg)
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.nx[c.Question(msg)] = time.Now()
+
+	return true
+}
+
+// ExpiredQueries (blocking) for returning all expired questions. Returns empty slice if c.ttl is < 0
+func (c *Queries) ExpiredQueries() []string {
+	if c.ttl < 0 {
+		return []string{}
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	questions := []string{}
+	for h, q := range c.resolved {
+		if time.Since(q.T) > time.Second*time.Duration(c.ttl) {
+			questions = append(questions, h)
+		}
+	}
+
+	return questions
+}
+
+// ExpiredMXQueries (blocking) for returning all expired NX questions. Returns empty slice if c.ttl is < 0
+func (c *Queries) ExpiredMXQueries() []string {
+	if c.ttl < 0 {
+		return []string{}
+	}
+
+	c.Lock()
+	defer c.Unlock()
+
+	questions := []string{}
+	for h, q := range c.nx {
+		if time.Since(q) > time.Second*time.Duration(c.ttl) {
+			questions = append(questions, h)
+		}
+	}
+
+	return questions
+}
+
+// Delete (blocking) for deleting a question from cache
+func (c *Queries) Delete(msg *dns.Msg) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.resolved, c.Question(msg))
+}
+
+// DeleteNX (blocking) for deleting a question from NX cache
+func (c *Queries) DeleteNX(msg *dns.Msg) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.nx, c.Question(msg))
+}

--- a/dns/errors.go
+++ b/dns/errors.go
@@ -1,11 +1,17 @@
 package dns
 
 var (
-	errFWDNSAddr        string = "forward dns host: addr  can not be empty"
-	errFWDNSAddrInvalid string = "forward dns address is not valid [%s:%s]"
-	errFWDNSProto       string = "forward tcp proto can be either tcp or udp"
-	errFWDTLS           string = "forward tls requires proto to be tcp"
-	errQuery            string = "invalid query, no questions"
-	errNotAFile         string = "[%s] is a directory"
-	warnFWDTLSPort      string = "forward tls is enabled but port is set to 53"
+	errFWDNSAddr           string = "forward dns host: addr  can not be empty"
+	errFWDNSAddrInvalid    string = "forward dns address is not valid [%s:%s]"
+	errFWDNSProto          string = "forward tcp proto can be either tcp or udp"
+	errFWDTLS              string = "forward tls requires proto to be tcp"
+	errQuery               string = "invalid query, no questions"
+	errNotAFile            string = "[%s] is a directory"
+	errManyQuestions       string = "[Invalid] query has more than 1 question [%s]"
+	errCacheFetch          string = "[Cache] something went wrong, could not fetch dns object from cache for question: %s"
+	errCacheRegister       string = "[Cache] could not register dns object with question %s to cache"
+	errCacheCoulndNotRenew string = "[Cache] could not renew object for question %s"
+	warnFWDTLSPort         string = "forward tls is enabled but port is set to 53"
+	infoCacheObjExpired    string = "[Cache] dns cache object with question %s has expired, asking upstream"
+	infoCacheObjFound      string = "[Cache] found dns object in cache for question %s"
 )

--- a/dns/listeners.go
+++ b/dns/listeners.go
@@ -1,0 +1,170 @@
+package dns
+
+import (
+	"context"
+	"crypto/tls"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/sirupsen/logrus"
+)
+
+// ServiceContext for canceling goroutins
+type ServiceContext struct {
+	cancel context.CancelFunc
+	wg     *sync.WaitGroup
+}
+
+// Expire will call cancel to terminate a context immediately, causing the goroutine to exit
+func (f *ServiceContext) Expire() {
+	f.cancel()
+}
+
+// Wait ensures that the goroutine has exit successfully
+func (f *ServiceContext) Wait() {
+	f.wg.Wait()
+}
+
+// UDPListenBackground for spawning a udp DNS Server
+func (s *Server) UDPListenBackground(fn func(resp *dns.Msg) error) *ServiceContext {
+	s.logger.WithFields(logrus.Fields{
+		"Component": "DNS Server",
+		"Stage":     "Init",
+	}).Info("Starting UDP DNS Server")
+
+	dnsServerContext := &ServiceContext{}
+
+	var serviceListenerWG sync.WaitGroup
+	dnsServerContext.wg = &serviceListenerWG
+
+	ctxListener, cancelListener := context.WithCancel(context.Background())
+	dnsServerContext.cancel = cancelListener
+
+	s.udpServer = &dns.Server{
+		Addr: s.listenAddr, Net: "udp",
+		Handler: dns.HandlerFunc(
+			func(w dns.ResponseWriter, r *dns.Msg) {
+				s.fwd(w, r, fn)
+			},
+		),
+	}
+
+	serviceListenerWG.Add(1)
+	go func(wg *sync.WaitGroup, srv *dns.Server) {
+		l := s.logger.WithFields(logrus.Fields{
+			"Component": "[UDP] DNSServer",
+			"Stage":     "Init",
+		})
+
+		l.Info("Starting")
+		if err := srv.ListenAndServe(); err != nil {
+			l.Error(err)
+		}
+		wg.Done()
+	}(&serviceListenerWG, s.udpServer)
+
+	serviceListenerWG.Add(1)
+	go func(ctx, ctxOnErr context.Context, wg *sync.WaitGroup, srv *dns.Server) {
+		l := s.logger.WithFields(logrus.Fields{
+			"Component": "[UDP] DNSServer",
+			"Stage":     "Term",
+		})
+
+		for {
+			select {
+			case <-ctx.Done():
+				if err := srv.Shutdown(); err != nil {
+					l.Fatal(err)
+				}
+				l.Info("Bye!")
+				wg.Done()
+				return
+			case <-ctxOnErr.Done():
+				s.killOnErr()
+			default:
+				time.Sleep(time.Millisecond * 50)
+			}
+		}
+	}(ctxListener, s.ctxOnErr, &serviceListenerWG, s.udpServer)
+
+	return dnsServerContext
+}
+
+// TCPListenBackground for spawning a tcp DNS Server
+func (s *Server) TCPListenBackground(fn func(resp *dns.Msg) error) *ServiceContext {
+	s.logger.WithFields(logrus.Fields{
+		"Component": "DNS Server",
+		"Stage":     "Init",
+	}).Info("Starting TCP DNS Server")
+
+	dnsServerContext := &ServiceContext{}
+
+	var serviceListenerWG sync.WaitGroup
+	dnsServerContext.wg = &serviceListenerWG
+
+	ctxListener, cancelListener := context.WithCancel(context.Background())
+	dnsServerContext.cancel = cancelListener
+
+	s.tcpServer = &dns.Server{
+		Addr: s.listenAddr, Net: "tcp",
+		Handler: dns.HandlerFunc(
+			func(w dns.ResponseWriter, r *dns.Msg) {
+				s.fwd(w, r, fn)
+			},
+		),
+	}
+
+	serviceListenerWG.Add(1)
+	go func(wg *sync.WaitGroup, srv *dns.Server) {
+		l := s.logger.WithFields(logrus.Fields{
+			"Component": "[TCP] DNSServer",
+			"Stage":     "Init",
+		})
+
+		if s.listenTLS {
+			l = s.logger.WithFields(logrus.Fields{
+				"Component": "[TLS] DNSServer",
+				"Stage":     "Init",
+			})
+
+			srv.TLSConfig = &tls.Config{
+				Certificates: []tls.Certificate{*s.listenCerts},
+			}
+
+			srv.Net = "tcp-tls"
+		}
+
+		l.Info("Starging")
+
+		if err := srv.ListenAndServe(); err != nil {
+			l.Error(err)
+		}
+		wg.Done()
+	}(&serviceListenerWG, s.tcpServer)
+
+	serviceListenerWG.Add(1)
+	go func(ctx, ctxOnErr context.Context, wg *sync.WaitGroup, srv *dns.Server) {
+		l := s.logger.WithFields(logrus.Fields{
+			"Component": "[TCP] DNSServer",
+			"Stage":     "Term",
+		})
+		for {
+			select {
+			case <-ctx.Done():
+				if err := srv.Shutdown(); err != nil {
+					l.Fatal(err)
+				}
+				l.Info("Bye!")
+				wg.Done()
+				return
+			case <-ctxOnErr.Done():
+				s.killOnErr()
+			default:
+				time.Sleep(time.Millisecond * 50)
+			}
+		}
+	}(ctxListener, s.ctxOnErr, &serviceListenerWG, s.tcpServer)
+
+	return dnsServerContext
+}

--- a/dns/proxy.go
+++ b/dns/proxy.go
@@ -1,0 +1,149 @@
+package dns
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+func (s *Server) fwd(w dns.ResponseWriter, req *dns.Msg, fn func(resp *dns.Msg) error) {
+	if len(req.Question) == 0 {
+		s.qErr(w, req, fmt.Errorf(errQuery))
+		return
+	}
+
+	if len(req.Question) > 1 {
+		dns.HandleFailed(w, req)
+		questions := []string{}
+
+		for _, j := range req.Question {
+			questions = append(questions, j.Name)
+		}
+
+		s.fwdl.Errorf(errManyQuestions, strings.Join(questions, " "))
+		return
+	}
+
+	var resp *dns.Msg
+	var question string
+	var err error
+
+	question = s.cache.Question(req)
+
+	if isCached := s.cache.Exists(req); isCached {
+		if hasExpired := s.cache.HasExpired(req); hasExpired {
+			s.cache.Delete(req)
+			s.fwdl.Debugf(infoCacheObjExpired, question)
+			goto forwardUpstream
+		}
+
+		r := s.cache.Get(req)
+		if r != nil {
+			s.fwdl.Debugf(infoCacheObjFound, question)
+			resp = r
+			resp.Id = req.Id
+			goto tellClient
+		}
+
+		s.fwdl.Errorf(errCacheFetch, question)
+	}
+
+	if isNXCached := s.cache.ExistsNX(req); isNXCached {
+		if hasExpired := s.cache.HasExpiredNX(req); !hasExpired {
+			s.fwdl.Debugf("[Cache] %s", question)
+			resp = req
+			goto tellClient
+		}
+
+		s.cache.DeleteNX(req)
+		s.fwdl.Debugf(infoCacheObjExpired, question)
+	}
+
+forwardUpstream:
+	resp, _, err = s.client.Exchange(req, s.fwdAddr)
+	if err != nil {
+		s.qErr(w, req, err)
+		return
+	}
+
+	err = s.pushToCache(resp)
+	if err != nil {
+		s.fwdl.Error(err)
+	}
+
+tellClient:
+	err = fn(resp)
+	if err != nil {
+		s.qErr(w, req, err)
+		return
+	}
+
+	err = w.WriteMsg(resp)
+	if err != nil {
+		s.qErr(w, req, err)
+	}
+}
+
+func (s *Server) qErr(w dns.ResponseWriter, req *dns.Msg, err error) {
+	s.fwdl.Error(err)
+	s.cache.RegisterNX(req)
+	dns.HandleFailed(w, req)
+}
+
+func (s *Server) pushToCache(msg *dns.Msg) error {
+	if len(msg.Answer) == 0 {
+		return s.registerNX(msg)
+	}
+
+	if len(msg.Answer) == 1 {
+		if q4, ok := msg.Answer[0].(*dns.A); ok {
+			if q4.A.String() == "0.0.0.0" {
+				return s.registerNX(msg)
+			}
+		}
+
+		if q6, ok := msg.Answer[0].(*dns.AAAA); ok {
+			if q6.AAAA.String() == "::" {
+				return s.registerNX(msg)
+			}
+		}
+	}
+
+	return s.register(msg)
+}
+
+func (s *Server) registerNX(msg *dns.Msg) error {
+	if exists := s.cache.ExistsNX(msg); exists {
+		if expired := s.cache.HasExpiredNX(msg); expired {
+			ok := s.cache.RenewNX(msg)
+			if !ok {
+				return fmt.Errorf(errCacheCoulndNotRenew, s.cache.Question(msg))
+			}
+		}
+		return nil
+	}
+	ok := s.cache.RegisterNX(msg)
+	if !ok {
+		return fmt.Errorf(errCacheRegister, s.cache.Question(msg))
+	}
+	return nil
+}
+
+func (s *Server) register(msg *dns.Msg) error {
+	if exists := s.cache.Exists(msg); exists {
+		if expired := s.cache.HasExpired(msg); expired {
+			ok := s.cache.Renew(msg)
+			if !ok {
+				return fmt.Errorf(errCacheCoulndNotRenew, s.cache.Question(msg))
+			}
+		}
+		return nil
+	}
+	ok := s.cache.Register(msg)
+	if !ok {
+		return fmt.Errorf(errCacheRegister, s.cache.Question(msg))
+	}
+
+	return nil
+}

--- a/firewall/firewall.go
+++ b/firewall/firewall.go
@@ -17,7 +17,7 @@ type Backend interface {
 	AddIPv4Set(n string) error
 	AddIPv4SetRule(n string) error
 	AddIPv4ToSetRule(n, ip string) error
-	DeleteIPv4FromSetRule(n, ip string) error
+	DeleteIPv4FromAuthorizedList(n, ip string) error
 	AddTailingReject() error
 	FlushTable(t string) error
 	DeleteChain(c string) error

--- a/firewall/nftables/nft4set.go
+++ b/firewall/nftables/nft4set.go
@@ -170,8 +170,8 @@ func (f *FirewallBackend) AddIPv4ToSetRule(n, ip string) error {
 	return f.nft.Flush()
 }
 
-// DeleteIPv4FromSetRule for deleting an IPv4 host from a set
-func (f *FirewallBackend) DeleteIPv4FromSetRule(n, ip string) error {
+// DeleteIPv4FromAuthorizedList for deleting an IPv4 host from a set
+func (f *FirewallBackend) DeleteIPv4FromAuthorizedList(n, ip string) error {
 	set, err := f.getIPv4Set(n)
 	if err != nil {
 		return err


### PR DESCRIPTION
* [dns] Include dns cache for storing DNS replies from the upstream
        On DNS Request, the cache is checked first before we forward
* [dns] Move fwd method into a new file dns/proxy.go
* [authorizer] Handle PTR records. On this commit we updated the handler
               to handle PTR records only. We also updated err, warn and
               info messages that NetTrust logs
* [core] move error messages under core/errors.go
* [firewall] rename DeleteIPv4FromSetRule to DeleteIPv4FromAuthorizedList