### PR TITLE
[dns/cache] fix nettrust/issues/5

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -3,8 +3,6 @@
 ## Fix
 
 - Conntrack activeHosts throws netfilter query error on MIPS64 SF
-- DNS Cache slows queries (Observed on TPLink Archer C7). Local DNS queries that are not cached take more time compared
-  when compared with the same queries without cache
 
 ## Improvements
 

--- a/dns/errors.go
+++ b/dns/errors.go
@@ -15,5 +15,6 @@ var (
 	warnFWDTLSPort         string = "forward tls is enabled but port is set to 53"
 	infoCacheObjExpired    string = "[Cache] dns cache object with question %s has expired, asking upstream"
 	infoCacheObjFound      string = "[Cache] found dns object in cache for question %s"
+	infoCacheObjFoundNil   string = "[Cache] found dns object in nil cache for question %s"
 	infoDomainBlacklist    string = "[Blacklisted] Question %s"
 )

--- a/dns/proxy.go
+++ b/dns/proxy.go
@@ -60,7 +60,7 @@ func (s *Server) fwd(w dns.ResponseWriter, req *dns.Msg, fn func(resp *dns.Msg) 
 
 	if isNXCached := s.cache.ExistsNX(req); isNXCached {
 		if hasExpired := s.cache.HasExpiredNX(req); !hasExpired {
-			s.fwdl.Debugf("[Cache] %s", question)
+			s.fwdl.Debugf(infoCacheObjFoundNil, question)
 			resp = req
 			goto tellClient
 		}
@@ -105,6 +105,10 @@ func (s *Server) qErr(w dns.ResponseWriter, req *dns.Msg, err error) {
 func (s *Server) pushToCache(msg *dns.Msg) error {
 	if len(msg.Answer) == 0 {
 		return s.registerNX(msg)
+	}
+
+	if msg.Answer[0].Header().Rrtype == dns.TypeAAAA {
+		return nil
 	}
 
 	if len(msg.Answer) == 1 {


### PR DESCRIPTION
* [dns/cache] add handler on push cache to escape AAAA records
  The root cause was that TPLink archer had IPv6 enabled
  by default. Since IPv6 queries are returned first by default
  hosts that supported only IPv4 were unable to connect
  because we were caching IPv6 answers and for the cache duration
  we would only retrun that answer. Now we are escaping AAAA cache
  responses. In the future when NetTrust will support IPv6 filtering
  we should cache these responses on a new cache
* [dns] fix debug nil cache message
* [ToDo.md] Update